### PR TITLE
bugfix:solve v5 cls model input size issue.

### DIFF
--- a/RapidOCRLib/AngleNet.cs
+++ b/RapidOCRLib/AngleNet.cs
@@ -16,9 +16,9 @@ namespace RapidOCRLib
     {
         private readonly float[] MeanValues = { 127.5F, 127.5F, 127.5F };
         private readonly float[] NormValues = { 1.0F / 127.5F, 1.0F / 127.5F, 1.0F / 127.5F };
-        private const int angleDstWidth = 192;
-        private const int angleDstHeight = 48;
         private const int angleCols = 2;
+        private int _dstWidth;
+        private int _dstHeight;
         private InferenceSession angleNet;
         private List<string> inputNames;
 
@@ -39,6 +39,12 @@ namespace RapidOCRLib
                 op.IntraOpNumThreads = numThread;
                 angleNet = new InferenceSession(path, op);
                 inputNames = angleNet.InputMetadata.Keys.ToList();
+
+                // 从 ONNX 模型 metadata 读取输入尺寸，兼容 v2 (192x48) 和 v5 (160x80)
+                var dims = angleNet.InputMetadata.First().Value.Dimensions;
+                _dstHeight = dims[2];
+                _dstWidth = dims[3];
+
                 await Task.CompletedTask;
             }
             catch (Exception ex)
@@ -105,7 +111,7 @@ namespace RapidOCRLib
         {
             Angle angle = new Angle();
             Mat angleImg = new Mat();
-            CvInvoke.Resize(src, angleImg, new Size(angleDstWidth, angleDstHeight));
+            CvInvoke.Resize(src, angleImg, new Size(_dstWidth, _dstHeight));
             Tensor<float> inputTensors = OcrUtils.SubstractMeanNormalize(angleImg, MeanValues, NormValues);
             var inputs = new List<NamedOnnxValue>
             {


### PR DESCRIPTION
`AngleNet` 中分类模型的输入尺寸被硬编码为 `192×48`，只能兼容 PP-OCRv2/v4 的 cls 模型。PP-OCRv5 换用了新的 PP-LCNet 架构，输入尺寸变为
  `160×80`，导致 ONNX 推理时报 `InvalidArgument` 错误。

  ## 根因

  `AngleNet.cs` 用编译期常量写死了 resize 尺寸：

  ```csharp
  private const int angleDstWidth = 192;
  private const int angleDstHeight = 48;

  而 PP-OCRv5 的 cls 模型（ch_PP-LCNet_x*_textline_ori_cls_*.onnx）期望 160×80 输入，导致：

  Got: 48 Expected: 80
  Got: 192 Expected: 160
```

## 修复

  改为在初始化时从 ONNX 模型 metadata 自动读取输入尺寸:

  - 在 InitModel 中从 InputMetadata 读取维度：
  ```csharp
  var dims = angleNet.InputMetadata.First().Value.Dimensions;
  _dstHeight = dims[2];  // v2=48, v5=80
  _dstWidth = dims[3];   // v2=192, v5=160
```